### PR TITLE
Add support for track and playlist playback commands

### DIFF
--- a/cmd/jarvis/main.go
+++ b/cmd/jarvis/main.go
@@ -34,6 +34,26 @@ func main() {
 		}
 		fmt.Println("Вы сказали:", text)
 
+		if trackName, ok := spotifyApi.ParsePlayTrackCommand(text); ok {
+			if err := spClient.PlayTrackByName(trackName); err != nil {
+				fmt.Println("Не удалось включить трек:", err)
+				speech.Say("Не нашёл трек")
+				continue
+			}
+			speech.Say("Включаю трек " + trackName)
+			continue
+		}
+
+		if playlistName, ok := spotifyApi.ParsePlayPlaylistCommand(text); ok {
+			if err := spClient.PlayPlaylistByName(playlistName); err != nil {
+				fmt.Println("Не удалось включить плейлист:", err)
+				speech.Say("Не нашёл плейлист")
+				continue
+			}
+			speech.Say("Включаю плейлист " + playlistName)
+			continue
+		}
+
 		switch {
 		case spotifyApi.IsNextCommand(text):
 			spClient.Next()


### PR DESCRIPTION
## Summary
- add Spotify client helpers to search and start playback for tracks and playlists by name
- extend voice command parsing to detect play track and play playlist requests
- invoke new playback helpers from the main loop with spoken feedback on success or failure

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e54bbe27ac8333873186fd7a12dca8